### PR TITLE
Downgrading `chart-releaser-action` to `v1.5.0`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,10 +25,9 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           skip_packaging: true
-          skip_existing: true
           packages_with_index: true
         env:
           CR_TOKEN: "${{ secrets.HELM_WORKFLOWS_TOKEN }}"


### PR DESCRIPTION
We are currently hitting the following issue with `v1.6.0` https://github.com/helm/chart-releaser-action/issues/171