### PR TITLE
Automate trigger release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,10 @@
 name: Release Charts
 
 on:
+  workflow_call:
+  repository_dispatch:
+    types:
+      - trigger-release
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-chart-created.yaml
+++ b/.github/workflows/sync-chart-created.yaml
@@ -36,3 +36,9 @@ jobs:
           git add charts
           git commit -m "Sync created chart ${{ github.event.client_payload.chart }} version ${{ github.event.client_payload.version }}"
           git push
+
+  trigger-release:
+    needs: build-index
+    name: Calls release workflow
+    uses: ./.github/workflows/release.yaml
+    secrets: inherit

--- a/.github/workflows/sync-chart-deleted.yaml
+++ b/.github/workflows/sync-chart-deleted.yaml
@@ -35,3 +35,9 @@ jobs:
           git add charts
           git commit -m "Sync deleted chart ${{ github.event.client_payload.chart }} version ${{ github.event.client_payload.version }}"
           git push
+
+  trigger-release:
+    needs: build-index
+    name: Calls release workflow
+    uses: ./.github/workflows/release.yaml
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,11 @@ helm-index: $(HELM) ## Update the helm repository index
 
 ##@ Sync chart packages
 
+# GitHub Release Asset Browser Download URL, it can be find in the output of the uploaded asse
 BROWSER_DOWNLOAD_URL ?= <BROWSER-DOWNLOAD-URL>
+# Dependency chart name, ie: limitador-operator
 CHART_NAME ?= <CHART-NAME>
+# Dependency chart semver, ie: 1.0.0
 CHART_VERSION ?= <CHART-VERSION>
 
 .PHONY: get-chart
@@ -58,3 +61,20 @@ get-chart: ## Get the chart package from its repository
 .PHONY: delete-chart
 delete-chart: ## Delete the chart package from its repository
 	rm -f ./charts/$(CHART_NAME)-$(CHART_VERSION).tgz
+
+# Organization
+ORG ?= kuadrant
+# GitHub Token with permissions to upload to the release assets
+HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>
+# Github repo name for the helm charts repository
+HELM_REPO_NAME ?= helm-charts
+
+.PHONY: trigger-release
+helm-sync-package-created: ## Trigger the release GH workflow, usually when the chart index has been updated
+	curl -L \
+	  -X POST \
+	  -H "Accept: application/vnd.github+json" \
+	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
+	  -H "X-GitHub-Api-Version: 2022-11-28" \
+	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
+	  -d '{"event_type":"trigger-release","client_payload":{}}'


### PR DESCRIPTION
Closes #16 

This PR introduces 2 additional methods of triggering the release workflow: `repository_dispatch` and `workflow_call`. Currently only used the later, and it's executed when the `chart_created` and `chart_deleted` `build_index` job has finished.

Notes:
* The make target `trigger-release` has been created as a backup/development method of triggering the workflow.