### PR TITLE
Update `chart-releaser-action`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,11 +29,11 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
+          charts_dir: charts
           skip_packaging: true
           skip_existing: true
           mark_as_latest: true
         env:
           CR_TOKEN: "${{ secrets.HELM_WORKFLOWS_TOKEN }}"
-          CR_PACKAGE_PATH: "./charts"


### PR DESCRIPTION
This PR bumps the [chart_releaser_action](https://github.com/helm/chart-releaser-action) in order to fix https://github.com/Kuadrant/helm-charts/actions/runs/13163340223/job/36746372273#step:5:143, which is addressed in https://github.com/helm/chart-releaser-action/pull/202