### PR TITLE
[ci] setting `packages_with_index`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
           skip_packaging: true
           skip_existing: true
           mark_as_latest: false
+          packages_with_index: true
         env:
           CR_TOKEN: "${{ secrets.HELM_WORKFLOWS_TOKEN }}"
           CR_PACKAGE_PATH: "./charts"


### PR DESCRIPTION
packages_with_index: When you set this to true, it will upload chart packages directly into publishing branch.