### PR TITLE
Using PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/sync-chart-created.yaml
+++ b/.github/workflows/sync-chart-created.yaml
@@ -1,3 +1,4 @@
+name: Sync Chart Created
 on:
   repository_dispatch:
     types:

--- a/.github/workflows/sync-chart-created.yaml
+++ b/.github/workflows/sync-chart-created.yaml
@@ -16,8 +16,9 @@ jobs:
           go-version: 1.21.x
         id: go
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
           fetch-depth: 0
       - name: Get chart package
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/sync-chart-deleted.yaml
+++ b/.github/workflows/sync-chart-deleted.yaml
@@ -16,8 +16,9 @@ jobs:
           go-version: 1.21.x
         id: go
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
           fetch-depth: 0
       - name: Delete chart package
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/sync-chart-deleted.yaml
+++ b/.github/workflows/sync-chart-deleted.yaml
@@ -1,3 +1,4 @@
+name: Sync Chart Deleted
 on:
   repository_dispatch:
     types:

--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -1,3 +1,4 @@
+name: Sync Docs
 on:
   push:
     branches:

--- a/.github/workflows/sync-index.yaml
+++ b/.github/workflows/sync-index.yaml
@@ -1,3 +1,4 @@
+name: Sync Index
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/sync-index.yaml
+++ b/.github/workflows/sync-index.yaml
@@ -13,11 +13,12 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |
           cp -f charts/index.yaml ${{ runner.temp }}/index.yaml
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
           ref: gh-pages
       - run: |
           cp -f ${{ runner.temp }}/index.yaml .


### PR DESCRIPTION
This is aimed to fix the trigger on push events when the previous commit came from an automated GH action. More info https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow